### PR TITLE
update documentation for get_service()

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -23,7 +23,7 @@ Quickstart
     env.name  # 'test-app'
     env.port  # 5000
 
-    redis = env.get_service('redis')
+    redis = env.get_service(label='redis')
     redis.credentials  # {'url': '...', 'password': '...'}
     redis.get_url(host='hostname', password='password', port='port')  # redis://pass:host
 


### PR DESCRIPTION
This seems to be what's required to get `cfenv` to find the service, based on some trial & error and what some other 18F projects are doing.