### PR TITLE
Fix packaging issue

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup(
     package_dir={'cfenv': 'cfenv'},
     include_package_data=True,
     install_requires=REQUIRES,
-    license=read('LICENSE'),
+    license='MIT',
     zip_safe=False,
     keywords='cloud foundry',
     classifiers=[


### PR DESCRIPTION
The `license` keyword should be the name of the license, not the
complete text.  Plus the `read()` breaks setuptools in certain
situations.

I ran into this while trying to vendor my dependencies for the python buildpack in CF.  If you run `pip download -d vendor --no-binary :all: -r requirements.txt` pip breaks on cfenv with the following message:

```
Collecting cfenv==0.5.2 (from -r requirements.txt (line 44))
  File was already downloaded /Users/yada/yada/vendor/cfenv-0.5.2.tar.gz
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/private/var/folders/94/bnnlwb5x3j1ckxch6flxkd2r0000gn/T/pip-build-XKXRZJ/cfenv/setup.py", line 44, in <module>
        license=read('LICENSE'),
      File "/private/var/folders/94/bnnlwb5x3j1ckxch6flxkd2r0000gn/T/pip-build-XKXRZJ/cfenv/setup.py", line 28, in read
        with open(fname) as fp:
    IOError: [Errno 2] No such file or directory: 'LICENSE'

    ----------------------------------------
Command "python setup.py egg_info" failed with error code 1 in /private/var/folders/94/bnnlwb5x3j1ckxch6flxkd2r0000gn/T/pip-build-XKXRZJ/cfenv/
```
I thought I always just used the name of the license as the `license` keyword to `setup()` and doublechecked myself.  The setuptools documentation mirrors my behavior, so I thought I'd commit this to just avoid the issue.