### PR TITLE
Added named_services to AppEnv

### DIFF
--- a/cfenv/__init__.py
+++ b/cfenv/__init__.py
@@ -38,12 +38,11 @@ class AppEnv(object):
 
     @property
     def port(self):
-        port = (
-            os.getenv('PORT') or
-            os.getenv('CF_INSTANCE_PORT') or
-            os.getenv('VCAP_APP_PORT')
-        )
-        return int(port) if port else None
+        for key in('PORT', 'CF_INSTANCE_PORT', 'VCAP_APP_PORT'):
+            port = os.getenv(key)
+            if port:
+                return int(port)
+        return None
 
     @property
     def bind(self):

--- a/cfenv/__init__.py
+++ b/cfenv/__init__.py
@@ -14,9 +14,12 @@ class AppEnv(object):
 
     def __init__(self):
         self.app = json.loads(os.getenv('VCAP_APPLICATION', '{}'))
+        env_services = json.loads(os.getenv('VCAP_SERVICES', '{}'))
+        self.named_services = {service_name: list(map(Service, services_list)) for service_name, services_list in
+                               env_services.items()}
         self.services = [
             Service(each)
-            for services in json.loads(os.getenv('VCAP_SERVICES', '{}')).values()
+            for services in env_services.values()
             for each in services
         ]
 

--- a/cfenv/__init__.py
+++ b/cfenv/__init__.py
@@ -15,8 +15,8 @@ class AppEnv(object):
     def __init__(self):
         self.app = json.loads(os.getenv('VCAP_APPLICATION', '{}'))
         env_services = json.loads(os.getenv('VCAP_SERVICES', '{}'))
-        self.named_services = {service_name: list(map(Service, services_list)) for service_name, services_list in
-                               env_services.items()}
+        self.named_services = {service_name: list(map(Service, services_list))
+                               for service_name, services_list in env_services.items()}
         self.services = [
             Service(each)
             for services in env_services.values()

--- a/tests/test_cfenv.py
+++ b/tests/test_cfenv.py
@@ -43,6 +43,16 @@ def services(monkeypatch):
                     'username': 'user',
                     'password': 'pass',
                 },
+            },
+            {
+                'name': 'test-database2',
+                'label': 'webscaledb2',
+                'plan': 'free',
+                'credentials': {
+                    'url': 'https://test-service2.com/',
+                    'username': 'user2',
+                    'password': 'pass2',
+                },
             }
         ],
     }
@@ -83,6 +93,12 @@ class TestEnv:
     def test_get_credential_default(self, env):
         assert env.get_credential('missing') is None
         assert env.get_credential('missing', 'default') == 'default'
+
+    def test_named_services(self, env):
+        assert len(env.named_services['test-credentials']) == 1
+        assert len(env.named_services['test-database']) == 2
+        assert env.named_services['test-database'][0].name == 'test-database'
+        assert env.named_services['test-database'][1].name == 'test-database2'
 
 class TestService:
 


### PR DESCRIPTION
I think it'll be useful to have a way to access all services of a certain name. E.g., "get all Postgres services". For this, I added AppEnv().named_services which is a dictionary that maps the name of a service to all its service instances.